### PR TITLE
Add support for 64-character secrets

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -12,14 +12,17 @@ lengths = []
 time_zone = "+0"
 
 def genKeyLine( code ):
-  key_b32 = code.replace(' ','').upper()
-  key_b32 = key_b32+'='*(32%len(key_b32))
-  key = base64.b32decode(key_b32)
+  secret_key = code.replace(' ','').upper()
+  if len(secret_key) <= 32:
+    key_b32 = secret_key+'='*(32%len(secret_key))
+    key = base64.b32decode(key_b32)
+  else:
+    key_b64 = secret_key+'='*(64%len(secret_key))
+    key = base64.b32decode(key_b64)
   key_bytes = map(ord,key)
   lengths.append( len(key_bytes) )
   key_hex = ["0x%02X" % x for x in key_bytes]
   return "{ " + ', '.join(key_hex) + " },"
-
 
 f = open( 'configuration.txt','r' )
 


### PR DESCRIPTION
Added a simple if/else check on the secret value to decided on whether to decode
a 32 character secret vs. a 64 character secret. This fix enabled me to use the
64-character Amazon Web Services secret for MFA.
